### PR TITLE
feat(CI) add GitHub action to publish Docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,35 @@
+name: Quay Image Push
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  push:
+    branches: [ main ]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Quay.io 
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: get short SHA
+        id: sha
+        run: |
+         echo ::set-output name=sha_short::$(git rev-parse --short=7 ${{ github.sha }})
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: |
+            quay.io/attcomdev/jarvis-connector:latest
+            quay.io/attcomdev/jarvis-connector:${{ steps.sha.outputs.sha_short }}


### PR DESCRIPTION
This action runs on updates to the main branch and every Sunday at midnight UTC. The action expects two secrets: QUAY_USERNAME and QUAY_PASSWORD to be available in the repository secrets. It will publish the image with two tags: latest, and the seven character shortened commit hash.