### PR TITLE
feat(voting-checks) adding blocking vote to gerrit checks

### DIFF
--- a/cmd/connector/connector.go
+++ b/cmd/connector/connector.go
@@ -77,9 +77,15 @@ func (gc *gerritChecker) ListCheckers() ([]*gerrit.CheckerInfo, error) {
 
 // PostChecker creates or changes a checker. It sets up a checker on
 // the given repo, for the given prefix.
-func (gc *gerritChecker) PostChecker(repo, prefix string, update bool) (*gerrit.CheckerInfo, error) {
+func (gc *gerritChecker) PostChecker(repo, prefix string, update bool, blocking bool) (*gerrit.CheckerInfo, error) {
 	hash := sha1.New()
 	hash.Write([]byte(repo))
+	var blockingList []string
+
+	// If the blocking flag is set to true, register the checker as a blocking checker
+	if blocking {
+		blockingList = append(blockingList, "STATE_NOT_PASSING")
+	}
 
 	uuid := fmt.Sprintf("%s:%s-%x", checkerScheme, prefix, hash.Sum(nil))
 	in := gerrit.CheckerInput{
@@ -89,7 +95,7 @@ func (gc *gerritChecker) PostChecker(repo, prefix string, update bool) (*gerrit.
 		URL:         "",
 		Repository:  repo,
 		Status:      "ENABLED",
-		Blocking:    []string{},
+		Blocking:    blockingList,
 		Query:       "status:open",
 	}
 

--- a/cmd/connector/main.go
+++ b/cmd/connector/main.go
@@ -34,6 +34,7 @@ var (
 	register         bool
 	update           bool
 	list             bool
+	blocking         bool
 	authFile         string
 	repo             string
 	prefix           string
@@ -45,6 +46,7 @@ func main() {
 	flag.BoolVar(&register, "register", false, "Register the connector with gerrit")
 	flag.BoolVar(&update, "update", false, "Update an existing check")
 	flag.BoolVar(&list, "list", false, "List pending checks")
+	flag.BoolVar(&blocking, "blocking", true, "check should block submission in event of failure")
 	flag.StringVar(&authFile, "auth_file", "", "file containing user:password")
 	flag.StringVar(&repo, "repo", "", "the repository (project) name to apply the checker to.")
 	flag.StringVar(&prefix, "prefix", "", "the prefix that the checker should use for jobs, this is also used as the job name in gerrit.")
@@ -109,7 +111,7 @@ func main() {
 			log.Fatalf("must set --prefix")
 		}
 
-		ch, err := gc.PostChecker(repo, prefix, update)
+		ch, err := gc.PostChecker(repo, prefix, update, blocking)
 		if err != nil {
 			log.Fatalf("CreateChecker: %v", err)
 		}


### PR DESCRIPTION
Adding a condition to the Checker creation enabling the checker to block merging if the state of a check is not passing. 'Blocking' Checkers will be create through the connector by default. To establish a non-verifying gate (one without the power to 'block'), simply set the flag --blocker=false when registering or updating a Checker.