### PR TITLE
[DNM] Adding methods to poll gerrit for ready-to-submit patchsets 

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -31,5 +31,5 @@ jobs:
         with:
           push: true
           tags: |
-            quay.io/attcomdev/jarvis-connector:latest
-            quay.io/attcomdev/jarvis-connector:${{ steps.sha.outputs.sha_short }}
+            quay.io/dannymassa/testrepo:latest
+            quay.io/dannymassa/testrepo:${{ steps.sha.outputs.sha_short }}

--- a/cmd/connector/main.go
+++ b/cmd/connector/main.go
@@ -120,10 +120,12 @@ func main() {
 			log.Fatal("must set --event_listener")
 		}
 
-		_, err = url.Parse(EventListenerURL)
+		el, err := url.Parse(EventListenerURL)
 		if err != nil {
 			log.Fatalf("url.Parse: %v", err)
 		}
+
+		gc.server.EventListenerURL = *el
 	}
 
 	gc.Serve()

--- a/gerrit/server.go
+++ b/gerrit/server.go
@@ -226,7 +226,18 @@ func (s *Server) PostCheck(changeID string, psID int, input *CheckInput) (*Check
 func (s *Server) HandleSubmissions() error {
 	u := s.URL
 
-	u.Path = path.Join(u.Path, "a/changes/?o=SUBMITTABLE&o=ALL_REVISIONS&q=is:open")
+	u.Path = path.Join(u.Path, "a/changes/") + "/"
+	req, err := http.NewRequest("GET", "http://gerrit.jarvis.local", nil)
+	if err != nil {
+		log.Printf("Error Line 232 of Server.go, something is wrong with request")
+		return err
+	}
+	q := req.URL.Query()
+	q.Add("o", "SUBMITTABLE")
+	q.Add("o", "ALL_REVISIONS")
+	q.Add("q", "is:open")
+	u.RawQuery= q.Encode()
+
 	content, err := s.Get(&u)
 	if err != nil {
 		return err

--- a/gerrit/server.go
+++ b/gerrit/server.go
@@ -21,17 +21,24 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
+)
+
+const (
+	JarvisMergeHashtag string = "jarvis-merge"
 )
 
 // Server represents a single Gerrit host.
 type Server struct {
-	UserAgent string
-	URL       url.URL
-	Client    http.Client
+	UserAgent        string
+	URL              url.URL
+	EventListenerURL url.URL
+	Client           http.Client
 
 	// Issue trace requests.
 	Debug bool
@@ -215,4 +222,171 @@ func (s *Server) PostCheck(changeID string, psID int, input *CheckInput) (*Check
 	}
 
 	return &out, nil
+}
+
+func (s *Server) HandleSubmissions() error {
+	u := s.URL
+
+	u.Path = path.Join(u.Path, "a/changes/") + "/"
+	q := u.Query()
+	q.Add("o", "SUBMITTABLE")
+	q.Add("o", "ALL_REVISIONS")
+	q.Add("q", "is:open")
+	u.RawQuery = q.Encode()
+
+	content, err := s.Get(&u)
+	if err != nil {
+		return err
+	}
+
+	var out []*PendingSubmitInfo
+	if err := Unmarshal(content, &out); err != nil {
+		return err
+	}
+
+	var patchsets []*PendingSubmitInfo
+
+	for i := 0; i < len(out); i++ {
+		// Ignore merge conflicts, patchsets without required labels, and patchsets currently being handled by Jarvis
+		if out[i].Mergeable == true && out[i].Subittable == true && !contains(out[i].Hashtags, JarvisMergeHashtag) {
+			patchsets = append(patchsets, out[i])
+		}
+	}
+
+	log.Printf("Sending %d patch sets to merge", len(patchsets))
+
+	for _, obj := range patchsets {
+
+		// Find the patch set number by checking the number of revisions that have been make to the change
+		obj.PatchsetNumber = len(obj.Revisions)
+
+		if err = s.PostHashtag(obj); err != nil {
+			log.Printf("PostHashtag Error: %v", err)
+			return err
+		}
+
+		if err = s.CallPipeline(obj); err != nil {
+			log.Printf("CallPipeline Error: %v", err)
+			return err
+		}
+	}
+
+	return nil
+}
+
+type PendingSubmitInfo struct {
+	Id              string                 `json:"id"`
+	Project         string                 `json:"project"`
+	Branch          string                 `json:"branch"`
+	Hashtags        []string               `json:"hashtags"`
+	ChangeId        string                 `json:"change_id"`
+	ChangeNumber    int                    `json:"_number"`
+	Subject         string                 `json:"subject"`
+	Status          string                 `json:"status"`
+	Created         Timestamp              `json:"created"`
+	Updated         Timestamp              `json:"updated"`
+	SubmitType      string                 `json:"submit_type"`
+	Mergeable       bool                   `json:"mergeable"`
+	Subittable      bool                   `json:"submittable"`
+	CurrentRevision string                 `json:"current_revision"`
+	Revisions       map[string]interface{} `json:"revisions"`
+	PatchsetNumber  int
+}
+
+type HashtagPayload struct {
+	Add    []string `json:"add"`
+	Remove []string `json:"remove"`
+}
+
+type TektonMergePayload struct {
+	RepoRoot       string `json:"repoRoot"`
+	Project        string `json:"project"`
+	ChangeNumber   string `json:"changeNumber"`
+	PatchSetNumber string `json:"patchSetNumber"`
+	CheckerUUID    string `json:"checkerUUID"`
+}
+
+func (s *Server) PostHashtag(patchset *PendingSubmitInfo) error {
+	u := s.URL
+	u.Path = path.Join(u.Path, fmt.Sprintf("a/changes/%s/hashtags/", patchset.ChangeId)) + "/"
+	hashtagPayload := HashtagPayload{
+		Add:    []string{JarvisMergeHashtag},
+		Remove: []string{},
+	}
+	body, err := json.Marshal(hashtagPayload)
+	if err != nil {
+		return err
+	}
+	_, err = s.PostPath(u.Path, "application/json", body)
+	if err != nil {
+		// return err
+		log.Printf("Error: %v", err)
+	}
+
+	return nil
+}
+
+func (s *Server) CallPipeline(patchset *PendingSubmitInfo) error {
+	checkerUUID, err := s.getChecker(patchset.Project)
+	if err != nil {
+		log.Printf("error finding relevant checker UUID: %v", err)
+	}
+
+	data := TektonMergePayload{
+		RepoRoot:       s.URL.String() + "/",
+		Project:        patchset.Project,
+		ChangeNumber:   strconv.Itoa(patchset.ChangeNumber),
+		PatchSetNumber: strconv.Itoa(patchset.PatchsetNumber),
+		CheckerUUID:    checkerUUID,
+	}
+	payloadBytes, err := json.Marshal(data)
+	if err != nil {
+		log.Printf("error marshalling request object: %v", err)
+	}
+	body := bytes.NewReader(payloadBytes)
+	req, err := http.NewRequest("POST", s.EventListenerURL.String(), body)
+	if err != nil {
+		log.Printf("error building request for Gerrit: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Jarvis", "merge")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Printf("error sending request to Gerrit: %v", err)
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+// TODO - Warning: This method assumes only one checker exists per repository.
+func (s *Server) getChecker(repository string) (string, error) {
+	content, err := s.GetPath("a/plugins/checks/checkers/")
+	if err != nil {
+		log.Fatal(err)
+	}
+	var out []*CheckerInfo
+	if err := Unmarshal(content, &out); err != nil {
+		return "", err
+	}
+
+	for i := 0; i < len(out); i++ {
+		// Ignore merge conflicts, patchsets without required labels, and patchsets currently being handled by Jarvis
+		if out[i].Repository == repository {
+			return out[i].UUID, nil
+		}
+	}
+
+	return "", nil
+}
+
+func contains(list []string, element string) bool {
+	for _, obj := range list {
+		if obj == element {
+			return true
+		}
+	}
+
+	return false
 }

--- a/gerrit/server.go
+++ b/gerrit/server.go
@@ -236,7 +236,7 @@ func (s *Server) HandleSubmissions() error {
 	q.Add("o", "SUBMITTABLE")
 	q.Add("o", "ALL_REVISIONS")
 	q.Add("q", "is:open")
-	u.RawQuery= q.Encode()
+	u.RawQuery = q.Encode()
 
 
 	content, err := s.Get(&u)
@@ -257,6 +257,8 @@ func (s *Server) HandleSubmissions() error {
 			patchsets = append(patchsets, out[i])
 		}
 	}
+
+	log.Printf("Sending %d patch sets to merge", len(patchsets))
 
 	for _, obj := range patchsets {
 
@@ -281,6 +283,7 @@ type PendingSubmitInfo struct {
 	Branch          string    `json:"branch"`
 	Hashtags        []string  `json:"hashtags"`
 	ChangeId        string    `json:"change_id"`
+	ChangeNumber    int       `json:"_number"`
 	Subject         string    `json:"subject"`
 	Status          string    `json:"status"`
 	Created         Timestamp `json:"created"`
@@ -332,7 +335,7 @@ func (s *Server) CallPipeline(patchset *PendingSubmitInfo) error {
 	data := TektonMergePayload{
 		RepoRoot:       "http://gerrit.jarvis.local/",
 		Project:        patchset.Project,
-		ChangeNumber:   patchset.ChangeId,
+		ChangeNumber:   strconv.Itoa(patchset.ChangeNumber),
 		PatchSetNumber: strconv.Itoa(patchset.PatchsetNumber),
 	}
 	payloadBytes, err := json.Marshal(data)

--- a/gerrit/server.go
+++ b/gerrit/server.go
@@ -333,7 +333,7 @@ func (s *Server) CallPipeline(patchset *PendingSubmitInfo) error {
 	EventListenerURL := "http://el-jarvis-system.jarvis-system.svc:8080"
 
 	data := TektonMergePayload{
-		RepoRoot:       "http://gerrit.jarvis.local/",
+		RepoRoot:       "http://gerrit.jarvis.local",
 		Project:        patchset.Project,
 		ChangeNumber:   strconv.Itoa(patchset.ChangeNumber),
 		PatchSetNumber: strconv.Itoa(patchset.PatchsetNumber),

--- a/gerrit/server.go
+++ b/gerrit/server.go
@@ -21,10 +21,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
+)
+
+const (
+	JarvisMergeHashtag string = "jarvis-merge"
 )
 
 // Server represents a single Gerrit host.
@@ -215,4 +221,133 @@ func (s *Server) PostCheck(changeID string, psID int, input *CheckInput) (*Check
 	}
 
 	return &out, nil
+}
+
+func (s *Server) HandleSubmissions() error {
+	u := s.URL
+
+	u.Path = path.Join(u.Path, "a/changes/?o=SUBMITTABLE&o=ALL_REVISIONS&q=is:open")
+	content, err := s.Get(&u)
+	if err != nil {
+		return err
+	}
+
+	var out []*PendingSubmitInfo
+	if err := Unmarshal(content, &out); err != nil {
+		return err
+	}
+
+	var patchsets []*PendingSubmitInfo
+	for i := 0; i < len(out); i++ {
+		// Ignore merge conflicts, patchsets without required labels, and patchsets currently being handled by Jarvis
+		if out[i].Mergeable == true && out[i].Subittable == true && !contains(out[i].Hashtags, JarvisMergeHashtag) {
+			patchsets = append(patchsets, out[i])
+		}
+	}
+
+	for _, obj := range patchsets {
+
+		// Find the patch set number by checking the number of revisions that have been make to the change
+		obj.PatchsetNumber = len(obj.Revisions)
+
+		if err = s.PostHashtag(obj); err != nil {
+			return err
+		}
+
+		if err = s.CallPipeline(obj); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type PendingSubmitInfo struct {
+	Id              string    `json:"id"`
+	Project         string    `json:"project"`
+	Branch          string    `json:"branch"`
+	Hashtags        []string  `json:"hashtags"`
+	ChangeId        string    `json:"change_id"`
+	Subject         string    `json:"subject"`
+	Status          string    `json:"status"`
+	Created         Timestamp `json:"created"`
+	Updated         Timestamp `json:"updated"`
+	SubmitType      string    `json:"submit_type"`
+	Mergeable       bool      `json:"mergeable"`
+	Subittable      bool      `json:"submittable"`
+	PatchsetNumber  int
+	CurrentRevision string                 `json:"current_revision"`
+	Revisions       map[string]interface{} `json:"revisions"`
+}
+
+type HashtagPayload struct {
+	Add    []string `json:"add"`
+	Remove []string `json:"remove"`
+}
+
+type TektonMergePayload struct {
+	RepoRoot       string `json:"repoRoot"`
+	Project        string `json:"project"`
+	ChangeNumber   string `json:"changeNumber"`
+	PatchSetNumber string `json:"patchSetNumber"`
+}
+
+func (s *Server) PostHashtag(patchset *PendingSubmitInfo) error {
+	u := s.URL
+	u.Path = path.Join(u.Path, fmt.Sprintf("a/changes/%s/hashtags/", patchset.ChangeId)) + "/"
+	hashtagPayload := HashtagPayload{
+		Add:    []string{JarvisMergeHashtag},
+		Remove: []string{},
+	}
+	body, err := json.Marshal(hashtagPayload)
+	if err != nil {
+		return err
+	}
+	_, err = s.PostPath(u.Path, "application/json", body)
+	if err != nil {
+		// return err
+		log.Printf("Error: %v", err)
+		log.Printf("If you are seeing this, the PostHashtag function isn't working")
+	}
+
+	return nil
+}
+
+func (s *Server) CallPipeline(patchset *PendingSubmitInfo) error {
+	EventListenerURL := "http://el-jarvis-system.jarvis-system.svc:8080"
+	data := TektonMergePayload{
+		RepoRoot:       "http://gerrit.jarvis.local/",
+		Project:        patchset.Project,
+		ChangeNumber:   patchset.ChangeId,
+		PatchSetNumber: strconv.Itoa(patchset.PatchsetNumber),
+	}
+	payloadBytes, err := json.Marshal(data)
+	if err != nil {
+		log.Fatal(err)
+	}
+	body := bytes.NewReader(payloadBytes)
+	req, err := http.NewRequest("POST", EventListenerURL, body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Jarvis", "merge")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func contains(list []string, element string) bool {
+	for _, obj := range list {
+		if obj == element {
+			return true
+		}
+	}
+
+	return false
 }

--- a/gerrit/server.go
+++ b/gerrit/server.go
@@ -21,10 +21,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
+)
+
+const (
+	JarvisMergeHashtag string = "jarvis-merge"
 )
 
 // Server represents a single Gerrit host.
@@ -215,4 +221,133 @@ func (s *Server) PostCheck(changeID string, psID int, input *CheckInput) (*Check
 	}
 
 	return &out, nil
+}
+
+func (s *Server) HandleSubmissions() error {
+	u := s.URL
+
+	u.Path = path.Join(u.Path, "a/changes/?o=SUBMITTABLE&q=is:open&o=ALL_REVISIONS")
+	content, err := s.Get(&u)
+	if err != nil {
+		return err
+	}
+
+	var out []*PendingSubmitInfo
+	if err := Unmarshal(content, &out); err != nil {
+		return err
+	}
+
+	patchsets := []*PendingSubmitInfo{}
+	for i := 0; i < len(out); i++ {
+		// Ignore merge conflicts, patchsets without required labels, and patchsets currently being handled by Jarvis
+		if out[i].Mergeable == true && out[i].Subittable == true && !contains(out[i].Hashtags, JarvisMergeHashtag) {
+			patchsets = append(patchsets, out[i])
+		}
+	}
+
+	for _, obj := range patchsets {
+
+		// Find the patch set number by checking the number of revisions that have been make to the change
+		obj.PatchsetNumber = len(obj.Revisions)
+
+		if err = s.PostHashtag(obj); err != nil {
+			return err
+		}
+
+		if err = s.CallPipeline(obj); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type PendingSubmitInfo struct {
+	Id              string    `json:"id"`
+	Project         string    `json:"project"`
+	Branch          string    `json:"branch"`
+	Hashtags        []string  `json:"hashtags"`
+	ChangeId        string    `json:"change_id"`
+	Subject         string    `json:"subject"`
+	Status          string    `json:"status"`
+	Created         Timestamp `json:"created"`
+	Updated         Timestamp `json:"updated"`
+	SubmitType      string    `json:"submit_type"`
+	Mergeable       bool      `json:"mergeable"`
+	Subittable      bool      `json:"submittable"`
+	PatchsetNumber  int
+	CurrentRevision string                 `json:"current_revision"`
+	Revisions       map[string]interface{} `json:"revisions"`
+}
+
+type HashtagPayload struct {
+	Add    []string `json:"add"`
+	Remove []string `json:"remove"`
+}
+
+type TektonMergePayload struct {
+	RepoRoot       string `json:"repoRoot"`
+	Project        string `json:"project"`
+	ChangeNumber   string `json:"changeNumber"`
+	PatchSetNumber string `json:"patchSetNumber"`
+}
+
+func (s *Server) PostHashtag(patchset *PendingSubmitInfo) error {
+	u := s.URL
+	u.Path = path.Join(u.Path, fmt.Sprintf("a/changes/%s/hashtags/", patchset.ChangeId)) + "/"
+	hashtagPayload := HashtagPayload{
+		Add:    []string{JarvisMergeHashtag},
+		Remove: []string{},
+	}
+	body, err := json.Marshal(hashtagPayload)
+	if err != nil {
+		return err
+	}
+	_, err = s.PostPath(u.Path, "application/json", body)
+	if err != nil {
+		// return err
+		log.Printf("Error: %v", err)
+		log.Printf("If you are seeing this, the PostHashtag function isn't working")
+	}
+
+	return nil
+}
+
+func (s *Server) CallPipeline(patchset *PendingSubmitInfo) error {
+	EventListenerURL := "https://98a722e7-a45f-4d7e-aac9-95d7ac58ce97.mock.pstmn.io"
+	data := TektonMergePayload{
+		RepoRoot:       "http://gerrit.jarvis.local/",
+		Project:        patchset.Project,
+		ChangeNumber:   patchset.ChangeId,
+		PatchSetNumber: strconv.Itoa(patchset.PatchsetNumber),
+	}
+	payloadBytes, err := json.Marshal(data)
+	if err != nil {
+		log.Fatal(err)
+	}
+	body := bytes.NewReader(payloadBytes)
+	req, err := http.NewRequest("POST", EventListenerURL, body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Jarvis", "merge")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func contains(list []string, element string) bool {
+	for _, obj := range list {
+		if obj == element {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
The patchsets are then locked with a hashtag, and sent to the jarvis-system to activate the merge-pipeline